### PR TITLE
feat: update tests to mock DevCycleClient and DVCVariables properly, fix bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ fastlane/screenshots/**/*.png
 fastlane/test_output
 
 .DS_Store
+.swiftpm/

--- a/Examples/OpenFeature-Example-App-Swift/OpenFeature-Example-App-Swift.xcodeproj/project.pbxproj
+++ b/Examples/OpenFeature-Example-App-Swift/OpenFeature-Example-App-Swift.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0F223B832DD6866900BA3C2B /* DevCycle in Frameworks */ = {isa = PBXBuildFile; productRef = 0F223B822DD6866900BA3C2B /* DevCycle */; };
 		0F223B852DD6866900BA3C2B /* DevCycleOpenFeatureProvider in Frameworks */ = {isa = PBXBuildFile; productRef = 0F223B842DD6866900BA3C2B /* DevCycleOpenFeatureProvider */; };
 		0F223B9A2DD78EF700BA3C2B /* DevCycleOpenFeatureProvider in Frameworks */ = {isa = PBXBuildFile; productRef = 0F223B992DD78EF700BA3C2B /* DevCycleOpenFeatureProvider */; };
+		0F6180312DD7C7E400F6DE29 /* DevCycleOpenFeatureProvider in Frameworks */ = {isa = PBXBuildFile; productRef = 0F6180302DD7C7E400F6DE29 /* DevCycleOpenFeatureProvider */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -46,6 +47,7 @@
 				0F223B832DD6866900BA3C2B /* DevCycle in Frameworks */,
 				0F223B852DD6866900BA3C2B /* DevCycleOpenFeatureProvider in Frameworks */,
 				0F223B9A2DD78EF700BA3C2B /* DevCycleOpenFeatureProvider in Frameworks */,
+				0F6180312DD7C7E400F6DE29 /* DevCycleOpenFeatureProvider in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -91,6 +93,7 @@
 				0F223B822DD6866900BA3C2B /* DevCycle */,
 				0F223B842DD6866900BA3C2B /* DevCycleOpenFeatureProvider */,
 				0F223B992DD78EF700BA3C2B /* DevCycleOpenFeatureProvider */,
+				0F6180302DD7C7E400F6DE29 /* DevCycleOpenFeatureProvider */,
 			);
 			productName = "DevCycle-iOS-OpenFeature-Example-App-Swift";
 			productReference = 0F7789192DCE9A41009E8E7E /* DevCycle-iOS-OpenFeature-Example-App-Swift.app */;
@@ -121,7 +124,7 @@
 			mainGroup = 0F7789102DCE9A41009E8E7E;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				0F223B982DD78EF700BA3C2B /* XCLocalSwiftPackageReference "../../../ios-openfeature-provider" */,
+				0F61802F2DD7C7E400F6DE29 /* XCLocalSwiftPackageReference "../../../ios-openfeature-provider" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 0F77891A2DCE9A41009E8E7E /* Products */;
@@ -353,7 +356,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		0F223B982DD78EF700BA3C2B /* XCLocalSwiftPackageReference "../../../ios-openfeature-provider" */ = {
+		0F61802F2DD7C7E400F6DE29 /* XCLocalSwiftPackageReference "../../../ios-openfeature-provider" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = "../../../ios-openfeature-provider";
 		};
@@ -369,6 +372,10 @@
 			productName = DevCycleOpenFeatureProvider;
 		};
 		0F223B992DD78EF700BA3C2B /* DevCycleOpenFeatureProvider */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = DevCycleOpenFeatureProvider;
+		};
+		0F6180302DD7C7E400F6DE29 /* DevCycleOpenFeatureProvider */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = DevCycleOpenFeatureProvider;
 		};

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .package(
             name: "DevCycle",
             url: "https://github.com/DevCycleHQ/ios-client-sdk.git",
-            .upToNextMajor(from: "1.18.0")
+            .upToNextMajor(from: "1.18.1")
         ),
     ],
     targets: [

--- a/Sources/DevCycleClientProtocol.swift
+++ b/Sources/DevCycleClientProtocol.swift
@@ -1,0 +1,32 @@
+import DevCycle
+import Foundation
+
+// Protocol for DevCycleClient used for dependency injection and testing.
+// Only includes the subset of methods needed by DevCycleProvider.
+public protocol DevCycleClientProtocol: AnyObject {
+    func variableValue(key: String, defaultValue: Bool) -> Bool
+    func variableValue(key: String, defaultValue: String) -> String
+    func variableValue(key: String, defaultValue: NSString) -> NSString
+    func variableValue(key: String, defaultValue: Double) -> Double
+    func variableValue(key: String, defaultValue: NSNumber) -> NSNumber
+    func variableValue(key: String, defaultValue: [String: Any]) -> [String: Any]
+    func variableValue(key: String, defaultValue: NSDictionary) -> NSDictionary
+    func variable<T>(key: String, defaultValue: T) -> DVCVariable<T>
+    func variable(key: String, defaultValue: Bool) -> DVCVariable<Bool>
+    func variable(key: String, defaultValue: String) -> DVCVariable<String>
+    func variable(key: String, defaultValue: NSString) -> DVCVariable<NSString>
+    func variable(key: String, defaultValue: Double) -> DVCVariable<Double>
+    func variable(key: String, defaultValue: NSNumber) -> DVCVariable<NSNumber>
+    func variable(key: String, defaultValue: [String: Any]) -> DVCVariable<[String: Any]>
+    func variable(key: String, defaultValue: NSDictionary) -> DVCVariable<NSDictionary>
+    func identifyUser(user: DevCycleUser, callback: ((Error?, [String: Variable]?) -> Void)?) throws
+    func resetUser(callback: ((Error?, [String: Variable]?) -> Void)?) throws
+    func allFeatures() -> [String: Feature]
+    func allVariables() -> [String: Variable]
+    func track(_ event: DevCycleEvent)
+    func flushEvents(callback: ((Error?) -> Void)?)
+    func close(callback: (() -> Void)?)
+}
+
+// Make DevCycleClient conform to the protocol
+extension DevCycleClient: DevCycleClientProtocol {}

--- a/Tests/MockDevCycleClient.swift
+++ b/Tests/MockDevCycleClient.swift
@@ -1,0 +1,79 @@
+import DevCycle
+import Foundation
+
+@testable import DevCycleOpenFeatureProvider
+
+class DVCVariableMock<T> {
+    var key: String
+    var value: T
+    var defaultValue: T
+    var isDefaulted: Bool
+    var evalReason: String?
+
+    init(
+        key: String, value: T, defaultValue: T, isDefaulted: Bool = true,
+        evalReason: String? = nil
+    ) {
+        self.key = key
+        self.value = value
+        self.defaultValue = defaultValue
+        self.isDefaulted = isDefaulted
+        self.evalReason = evalReason
+    }
+}
+
+class MockDevCycleClient: DevCycleClientProtocol {
+    var mockVariableValue: [String: Any] = [:]
+    var mockIsDefaulted: Bool = true
+    var mockEvalReason: String? = nil
+    var shouldDefault: Bool = true
+
+    private func makeMockVariable<T>(key: String, defaultValue: T) -> DVCVariable<T> {
+        let value: T? = shouldDefault ? nil : defaultValue
+        return DVCVariable(key: key, value: value, defaultValue: defaultValue, evalReason: nil)
+    }
+
+    func variableValue(key: String, defaultValue: Bool) -> Bool { defaultValue }
+    func variableValue(key: String, defaultValue: String) -> String { defaultValue }
+    func variableValue(key: String, defaultValue: NSString) -> NSString { defaultValue }
+    func variableValue(key: String, defaultValue: Double) -> Double { defaultValue }
+    func variableValue(key: String, defaultValue: NSNumber) -> NSNumber { defaultValue }
+    func variableValue(key: String, defaultValue: [String: Any]) -> [String: Any] { defaultValue }
+    func variableValue(key: String, defaultValue: NSDictionary) -> NSDictionary { defaultValue }
+    func variable<T>(key: String, defaultValue: T) -> DVCVariable<T> {
+        makeMockVariable(key: key, defaultValue: defaultValue)
+    }
+    func variable(key: String, defaultValue: Bool) -> DVCVariable<Bool> {
+        makeMockVariable(key: key, defaultValue: defaultValue)
+    }
+    func variable(key: String, defaultValue: String) -> DVCVariable<String> {
+        makeMockVariable(key: key, defaultValue: defaultValue)
+    }
+    func variable(key: String, defaultValue: NSString) -> DVCVariable<NSString> {
+        makeMockVariable(key: key, defaultValue: defaultValue)
+    }
+    func variable(key: String, defaultValue: Double) -> DVCVariable<Double> {
+        makeMockVariable(key: key, defaultValue: defaultValue)
+    }
+    func variable(key: String, defaultValue: NSNumber) -> DVCVariable<NSNumber> {
+        makeMockVariable(key: key, defaultValue: defaultValue)
+    }
+    func variable(key: String, defaultValue: [String: Any]) -> DVCVariable<[String: Any]> {
+        makeMockVariable(key: key, defaultValue: defaultValue)
+    }
+    func variable(key: String, defaultValue: NSDictionary) -> DVCVariable<NSDictionary> {
+        makeMockVariable(key: key, defaultValue: defaultValue)
+    }
+    func identifyUser(user: DevCycleUser, callback: ((Error?, [String: Variable]?) -> Void)?) throws
+    {
+        callback?(nil, nil)
+    }
+    func resetUser(callback: ((Error?, [String: Variable]?) -> Void)?) throws {
+        callback?(nil, nil)
+    }
+    func allFeatures() -> [String: Feature] { [:] }
+    func allVariables() -> [String: Variable] { [:] }
+    func track(_ event: DevCycleEvent) {}
+    func flushEvents(callback: ((Error?) -> Void)?) { callback?(nil) }
+    func close(callback: (() -> Void)?) { callback?() }
+}


### PR DESCRIPTION
- Update tests to properly mock `DevCycleClient` and `DVCVariable` from the DevCycle SDK
- fix some type conversion issues

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
