### PR TITLE
fix: supporting OpenFeature Contexts with just isAnonymous=true set

### DIFF
--- a/Examples/OpenFeature-Example-App-Swift/OpenFeature-Example-App-Swift/OpenFeatureManager.swift
+++ b/Examples/OpenFeature-Example-App-Swift/OpenFeature-Example-App-Swift/OpenFeatureManager.swift
@@ -26,8 +26,20 @@ class OpenFeatureManager {
         self.provider = dvcProvider
 
         Task {
+            let userContext: EvaluationContext
+            if let user = user {
+                userContext = user
+            } else {
+                // if no user, create anonymous user
+                userContext = MutableContext(
+                    structure: MutableStructure(attributes: [
+                        "isAnonymous": .boolean(true)
+                    ])
+                )
+            }
+
             await OpenFeatureAPI.shared.setProviderAndWait(
-                provider: dvcProvider, initialContext: user)
+                provider: dvcProvider, initialContext: userContext)
         }
     }
 }

--- a/Examples/OpenFeature-Example-App-Swift/OpenFeature-Example-App-Swift/OpenFeatureManager.swift
+++ b/Examples/OpenFeature-Example-App-Swift/OpenFeature-Example-App-Swift/OpenFeatureManager.swift
@@ -10,7 +10,7 @@ import Foundation
 import OpenFeature
 
 struct DevCycleKeys {
-    static var DEVELOPMENT = "<DEVCYCLE_MOBILE_SDK_KEY>"
+    static var DEVELOPMENT = "YOUR_DEVCYCLE_SDK_KEY_HERE"
 }
 
 class OpenFeatureManager {

--- a/Examples/OpenFeature-Example-App-Swift/OpenFeature-Example-App-Swift/OpenFeatureManager.swift
+++ b/Examples/OpenFeature-Example-App-Swift/OpenFeature-Example-App-Swift/OpenFeatureManager.swift
@@ -10,7 +10,7 @@ import Foundation
 import OpenFeature
 
 struct DevCycleKeys {
-    static var DEVELOPMENT = "YOUR_DEVCYCLE_SDK_KEY_HERE"
+    static var DEVELOPMENT = "<DEVCYCLE_MOBILE_SDK_KEY>"
 }
 
 class OpenFeatureManager {

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .package(
             name: "DevCycle",
             url: "https://github.com/DevCycleHQ/ios-client-sdk.git",
-            .upToNextMajor(from: "1.18.1")
+            .upToNextMajor(from: "1.21.0")
         ),
     ],
     targets: [


### PR DESCRIPTION
Fixing the OpenFeature provider to support Contexts for anonymous users, this is a valid Context:

```swift
let context = MutableContext(
    structure: MutableStructure(attributes: [
        "isAnonymous": .boolean(true)
    ])
)
```

just as this is a valid `DevCycleUser`:
```swift
let user = DevCycleUser.builder().isAnonymous(true).build()
```
