### PR TITLE
feat: adds eval reason

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .package(
             name: "DevCycle",
             url: "https://github.com/DevCycleHQ/ios-client-sdk.git",
-            .upToNextMajor(from: "1.21.0")
+            .upToNextMajor(from: "1.21.2")
         ),
     ],
     targets: [

--- a/Sources/DevCycleProvider.swift
+++ b/Sources/DevCycleProvider.swift
@@ -177,8 +177,8 @@ public final class DevCycleProvider: FeatureProvider {
         let variable = devcycleClient!.variable(key: key, defaultValue: defaultValue)
         return ProviderEvaluation(
             value: variable.value,
-            reason: variable.isDefaulted
-                ? Reason.defaultReason.rawValue : Reason.targetingMatch.rawValue
+            reason: DevCycleProvider.getEvalReason(
+                isDefaulted: variable.isDefaulted, evalReason: variable.eval)
         )
     }
 
@@ -206,8 +206,8 @@ public final class DevCycleProvider: FeatureProvider {
         let variable = devcycleClient!.variable(key: key, defaultValue: defaultValue)
         return ProviderEvaluation(
             value: variable.value,
-            reason: variable.isDefaulted
-                ? Reason.defaultReason.rawValue : Reason.targetingMatch.rawValue
+            reason: DevCycleProvider.getEvalReason(
+                isDefaulted: variable.isDefaulted, evalReason: variable.eval)
         )
     }
 
@@ -238,8 +238,8 @@ public final class DevCycleProvider: FeatureProvider {
 
         return ProviderEvaluation(
             value: Int64(variable.value),
-            reason: variable.isDefaulted
-                ? Reason.defaultReason.rawValue : Reason.targetingMatch.rawValue
+            reason: DevCycleProvider.getEvalReason(
+                isDefaulted: variable.isDefaulted, evalReason: variable.eval)
         )
     }
 
@@ -267,8 +267,8 @@ public final class DevCycleProvider: FeatureProvider {
         let variable = devcycleClient!.variable(key: key, defaultValue: defaultValue)
         return ProviderEvaluation(
             value: variable.value,
-            reason: variable.isDefaulted
-                ? Reason.defaultReason.rawValue : Reason.targetingMatch.rawValue
+            reason: DevCycleProvider.getEvalReason(
+                isDefaulted: variable.isDefaulted, evalReason: variable.eval)
         )
     }
 
@@ -299,8 +299,8 @@ public final class DevCycleProvider: FeatureProvider {
         return ProviderEvaluation(
             value: variable.isDefaulted
                 ? defaultValue : DevCycleProvider.convertDictionaryToValue(variable.value),
-            reason: variable.isDefaulted
-                ? Reason.defaultReason.rawValue : Reason.targetingMatch.rawValue
+            reason: DevCycleProvider.getEvalReason(
+                isDefaulted: variable.isDefaulted, evalReason: variable.eval)
         )
     }
 
@@ -543,5 +543,12 @@ public final class DevCycleProvider: FeatureProvider {
             }
         }
         return customData
+    }
+
+    internal static func getEvalReason(isDefaulted: Bool, evalReason: EvalReason?) -> String {
+        if let evalReason = evalReason {
+            return evalReason.reason
+        }
+        return isDefaulted ? Reason.defaultReason.rawValue : Reason.targetingMatch.rawValue
     }
 }

--- a/Sources/DevCycleProvider.swift
+++ b/Sources/DevCycleProvider.swift
@@ -177,8 +177,7 @@ public final class DevCycleProvider: FeatureProvider {
         let variable = devcycleClient!.variable(key: key, defaultValue: defaultValue)
         return ProviderEvaluation(
             value: variable.value,
-            reason: DevCycleProvider.getEvalReason(
-                isDefaulted: variable.isDefaulted, evalReason: variable.eval)
+            reason: DevCycleProvider.getEvalReason(variable: variable)
         )
     }
 
@@ -206,8 +205,7 @@ public final class DevCycleProvider: FeatureProvider {
         let variable = devcycleClient!.variable(key: key, defaultValue: defaultValue)
         return ProviderEvaluation(
             value: variable.value,
-            reason: DevCycleProvider.getEvalReason(
-                isDefaulted: variable.isDefaulted, evalReason: variable.eval)
+            reason: DevCycleProvider.getEvalReason(variable: variable)
         )
     }
 
@@ -238,8 +236,7 @@ public final class DevCycleProvider: FeatureProvider {
 
         return ProviderEvaluation(
             value: Int64(variable.value),
-            reason: DevCycleProvider.getEvalReason(
-                isDefaulted: variable.isDefaulted, evalReason: variable.eval)
+            reason: DevCycleProvider.getEvalReason(variable: variable)
         )
     }
 
@@ -267,8 +264,7 @@ public final class DevCycleProvider: FeatureProvider {
         let variable = devcycleClient!.variable(key: key, defaultValue: defaultValue)
         return ProviderEvaluation(
             value: variable.value,
-            reason: DevCycleProvider.getEvalReason(
-                isDefaulted: variable.isDefaulted, evalReason: variable.eval)
+            reason: DevCycleProvider.getEvalReason(variable: variable)
         )
     }
 
@@ -299,8 +295,7 @@ public final class DevCycleProvider: FeatureProvider {
         return ProviderEvaluation(
             value: variable.isDefaulted
                 ? defaultValue : DevCycleProvider.convertDictionaryToValue(variable.value),
-            reason: DevCycleProvider.getEvalReason(
-                isDefaulted: variable.isDefaulted, evalReason: variable.eval)
+            reason: DevCycleProvider.getEvalReason(variable: variable)
         )
     }
 
@@ -545,10 +540,10 @@ public final class DevCycleProvider: FeatureProvider {
         return customData
     }
 
-    internal static func getEvalReason(isDefaulted: Bool, evalReason: EvalReason?) -> String {
-        if let evalReason = evalReason {
+    internal static func getEvalReason<T>(variable: DVCVariable<T>) -> String {
+        if let evalReason = variable.eval {
             return evalReason.reason
         }
-        return isDefaulted ? Reason.defaultReason.rawValue : Reason.targetingMatch.rawValue
+        return variable.isDefaulted ? Reason.defaultReason.rawValue : Reason.targetingMatch.rawValue
     }
 }

--- a/Tests/DevCycleProviderTests.swift
+++ b/Tests/DevCycleProviderTests.swift
@@ -123,7 +123,7 @@ final class DevCycleProviderTests: XCTestCase {
     // MARK: - Object Evaluation Tests
 
     func testObjectEvaluation() throws {
-        mockClient.shouldDefault = false
+        mockClient.shouldDefault = true
 
         // Test object evaluation with a complex structure
         let defaultValue = Value.structure([
@@ -156,7 +156,7 @@ final class DevCycleProviderTests: XCTestCase {
     }
 
     func testComplexObjectEvaluation() throws {
-        mockClient.shouldDefault = false
+        mockClient.shouldDefault = true
 
         // Test object evaluation with mixed types
         let defaultValue = Value.structure([
@@ -1000,35 +1000,35 @@ final class DevCycleProviderTests: XCTestCase {
         let listResult = try provider.getObjectEvaluation(
             key: "json-flag-list", defaultValue: listDefault, context: nil)
         XCTAssertEqual(listResult.value, .structure([:]))
-        XCTAssertEqual(listResult.reason, Reason.targetingMatch.rawValue)
+        XCTAssertEqual(listResult.reason, "TARGETING_MATCH")
 
         // .double
         let doubleDefault = Value.double(610)
         let doubleResult = try provider.getObjectEvaluation(
             key: "json-flag-double", defaultValue: doubleDefault, context: nil)
         XCTAssertEqual(doubleResult.value, .structure([:]))
-        XCTAssertEqual(doubleResult.reason, Reason.targetingMatch.rawValue)
+        XCTAssertEqual(doubleResult.reason, "TARGETING_MATCH")
 
         // .boolean
         let boolDefault = Value.boolean(false)
         let boolResult = try provider.getObjectEvaluation(
             key: "json-flag-bool", defaultValue: boolDefault, context: nil)
         XCTAssertEqual(boolResult.value, .structure([:]))
-        XCTAssertEqual(boolResult.reason, Reason.targetingMatch.rawValue)
+        XCTAssertEqual(boolResult.reason, "TARGETING_MATCH")
 
         // .string
         let stringDefault = Value.string("string")
         let stringResult = try provider.getObjectEvaluation(
             key: "json-flag-string", defaultValue: stringDefault, context: nil)
         XCTAssertEqual(stringResult.value, .structure([:]))
-        XCTAssertEqual(stringResult.reason, Reason.targetingMatch.rawValue)
+        XCTAssertEqual(stringResult.reason, "TARGETING_MATCH")
 
         // .null
         let nullDefault = Value.null
         let nullResult = try provider.getObjectEvaluation(
             key: "json-flag-null", defaultValue: nullDefault, context: nil)
         XCTAssertEqual(nullResult.value, .structure([:]))
-        XCTAssertEqual(nullResult.reason, Reason.targetingMatch.rawValue)
+        XCTAssertEqual(nullResult.reason, "TARGETING_MATCH")
 
         // .date
         let date = Date()
@@ -1036,7 +1036,7 @@ final class DevCycleProviderTests: XCTestCase {
         let dateResult = try provider.getObjectEvaluation(
             key: "json-flag-date", defaultValue: dateDefault, context: nil)
         XCTAssertEqual(dateResult.value, .structure([:]))
-        XCTAssertEqual(dateResult.reason, Reason.targetingMatch.rawValue)
+        XCTAssertEqual(dateResult.reason, "TARGETING_MATCH")
     }
 
     func testGetObjectEvaluationWithStructureValueIsAccepted() throws {
@@ -1046,6 +1046,6 @@ final class DevCycleProviderTests: XCTestCase {
         let structureResult = try provider.getObjectEvaluation(
             key: "json-flag-structure", defaultValue: structureDefault, context: nil)
         XCTAssertEqual(structureResult.value, structureDefault)
-        XCTAssertEqual(structureResult.reason, Reason.targetingMatch.rawValue)
+        XCTAssertEqual(structureResult.reason, "TARGETING_MATCH")
     }
 }

--- a/Tests/DevCycleProviderTests.swift
+++ b/Tests/DevCycleProviderTests.swift
@@ -138,7 +138,7 @@ final class DevCycleProviderTests: XCTestCase {
         let result = try provider.getObjectEvaluation(
             key: "test-object", defaultValue: defaultValue, context: nil as EvaluationContext?)
 
-        XCTAssertEqual(result.reason, Reason.targetingMatch.rawValue)
+        XCTAssertEqual(result.reason, Reason.defaultReason.rawValue)
 
         if case .structure(let attributes) = result.value {
             XCTAssertEqual(attributes["name"], .string("John"))
@@ -172,7 +172,7 @@ final class DevCycleProviderTests: XCTestCase {
             context: nil as EvaluationContext?
         )
 
-        XCTAssertEqual(result.reason, Reason.targetingMatch.rawValue)
+        XCTAssertEqual(result.reason, Reason.defaultReason.rawValue)
 
         if case .structure(let attributes) = result.value {
             XCTAssertEqual(attributes["string"], .string("text"))

--- a/Tests/MockDevCycleClient.swift
+++ b/Tests/MockDevCycleClient.swift
@@ -30,7 +30,7 @@ class MockDevCycleClient: DevCycleClientProtocol {
 
     private func makeMockVariable<T>(key: String, defaultValue: T) -> DVCVariable<T> {
         let value: T? = shouldDefault ? nil : defaultValue
-        return DVCVariable(key: key, value: value, defaultValue: defaultValue, evalReason: nil)
+        return DVCVariable(key: key, value: value, defaultValue: defaultValue, eval: nil)
     }
 
     func variableValue(key: String, defaultValue: Bool) -> Bool { defaultValue }

--- a/Tests/MockDevCycleClient.swift
+++ b/Tests/MockDevCycleClient.swift
@@ -25,12 +25,14 @@ class DVCVariableMock<T> {
 class MockDevCycleClient: DevCycleClientProtocol {
     var mockVariableValue: [String: Any] = [:]
     var mockIsDefaulted: Bool = true
-    var mockEvalReason: String? = nil
     var shouldDefault: Bool = true
 
     private func makeMockVariable<T>(key: String, defaultValue: T) -> DVCVariable<T> {
         let value: T? = shouldDefault ? nil : defaultValue
-        return DVCVariable(key: key, value: value, defaultValue: defaultValue, eval: nil)
+        
+        // Requires DevCycle 1.24.2
+        let evalReason = shouldDefault ? nil : EvalReason.createOFEvalReason(reason: "TARGETING_MATCH")
+        return DVCVariable(key: key, value: value, defaultValue: defaultValue, eval: evalReason)
     }
 
     func variableValue(key: String, defaultValue: Bool) -> Bool { defaultValue }


### PR DESCRIPTION
- feat: adds parsing of DevCycle Eval Reasons to the proper OpenFeature format
- chore: update tests expectations for `result.reason` to properly map to expected reasons
- fix: sets min DevCycle version to `1.21.2` to prevent crashes due to new properties on configs 